### PR TITLE
Unlock async test and expectation APIs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,14 @@ project(XCTest LANGUAGES Swift)
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 option(USE_FOUNDATION_FRAMEWORK "Use Foundation.framework on Darwin" NO)
 
+set(USE_SWIFT_CONCURRENCY_WAITER_default NO)
+
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL wasm32)
+  set(USE_SWIFT_CONCURRENCY_WAITER_default ON)
+endif()
+
+option(USE_SWIFT_CONCURRENCY_WAITER "Use Swift Concurrency-based waiter implementation" "${USE_SWIFT_CONCURRENCY_WAITER_default}")
+
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin AND NOT CMAKE_SYSTEM_PROCESSOR STREQUAL wasm32)
   find_package(dispatch CONFIG REQUIRED)
   find_package(Foundation CONFIG REQUIRED)
@@ -22,13 +30,9 @@ endif()
 set(XCTEST_WASI_UNAVAILABLE_SOURCES)
 if(NOT CMAKE_SYSTEM_NAME STREQUAL WASI)
 list(APPEND XCTEST_WASI_UNAVAILABLE_SOURCES
-  Sources/XCTest/Private/WaiterManager.swift
-  Sources/XCTest/Public/Asynchronous/XCTestCase+Asynchronous.swift
-  Sources/XCTest/Public/Asynchronous/XCTestExpectation.swift
   Sources/XCTest/Public/Asynchronous/XCTNSNotificationExpectation.swift
   Sources/XCTest/Public/Asynchronous/XCTNSPredicateExpectation.swift
-  Sources/XCTest/Public/Asynchronous/XCTWaiter.swift
-  Sources/XCTest/Public/Asynchronous/XCTWaiter+Validation.swift)
+  Sources/XCTest/Public/Asynchronous/XCTestCase+Asynchronous.swift)
 endif()
 
 add_library(XCTest
@@ -40,10 +44,12 @@ add_library(XCTest
   Sources/XCTest/Private/PrintObserver.swift
   Sources/XCTest/Private/ArgumentParser.swift
   Sources/XCTest/Private/SourceLocation.swift
+  Sources/XCTest/Private/WaiterManager.swift
   Sources/XCTest/Private/IgnoredErrors.swift
   Sources/XCTest/Private/PerformanceMeter.swift
   Sources/XCTest/Private/WallClockTimeMetric.swift
   Sources/XCTest/Private/XCTestCase.TearDownBlocksState.swift
+  Sources/XCTest/Private/Shims.swift
   Sources/XCTest/Public/XCTestCase+Performance.swift
   Sources/XCTest/Public/CodableObserver.swift
   Sources/XCTest/Public/XCTestRun.swift
@@ -58,8 +64,17 @@ add_library(XCTest
   Sources/XCTest/Public/XCTestObservationCenter.swift
   Sources/XCTest/Public/XCTAssert.swift
   Sources/XCTest/Public/XCTSkip.swift
+  Sources/XCTest/Public/Asynchronous/XCTWaiter+Validation.swift
+  Sources/XCTest/Public/Asynchronous/XCTWaiter.swift
+  Sources/XCTest/Public/Asynchronous/XCTestExpectation.swift
   
   ${XCTEST_WASI_UNAVAILABLE_SOURCES})
+
+if(USE_SWIFT_CONCURRENCY_WAITER)
+  target_compile_definitions(XCTest PRIVATE
+    USE_SWIFT_CONCURRENCY_WAITER)
+endif()
+
 if(USE_FOUNDATION_FRAMEWORK)
   target_compile_definitions(XCTest PRIVATE
     USE_FOUNDATION_FRAMEWORK)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.15.1)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 
-project(XCTest LANGUAGES Swift)
+project(XCTest LANGUAGES Swift CXX)
 
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 option(USE_FOUNDATION_FRAMEWORK "Use Foundation.framework on Darwin" NO)
@@ -69,6 +69,14 @@ add_library(XCTest
   Sources/XCTest/Public/Asynchronous/XCTestExpectation.swift
   
   ${XCTEST_WASI_UNAVAILABLE_SOURCES})
+
+add_library(XCTestConcurrencySupport OBJECT
+  Sources/XCTest/Private/ConcurrencySupport/ConcurrencySupport.cpp)
+add_dependencies(XCTest XCTestConcurrencySupport)
+
+set_property(TARGET XCTest PROPERTY STATIC_LIBRARY_OPTIONS
+  $<TARGET_OBJECTS:XCTestConcurrencySupport>)
+target_link_options(XCTest PRIVATE $<TARGET_OBJECTS:XCTestConcurrencySupport>)
 
 if(USE_SWIFT_CONCURRENCY_WAITER)
   target_compile_definitions(XCTest PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ add_library(XCTest
 
 add_library(XCTestConcurrencySupport OBJECT
   Sources/XCTest/Private/ConcurrencySupport/ConcurrencySupport.cpp)
+set_property(TARGET XCTestConcurrencySupport PROPERTY POSITION_INDEPENDENT_CODE ON)
 add_dependencies(XCTest XCTestConcurrencySupport)
 
 set_property(TARGET XCTest PROPERTY STATIC_LIBRARY_OPTIONS

--- a/Sources/XCTest/Private/ConcurrencySupport/ConcurrencySupport.cpp
+++ b/Sources/XCTest/Private/ConcurrencySupport/ConcurrencySupport.cpp
@@ -9,7 +9,7 @@
 SWIFT_EXPORT_FROM(swift_Concurrency)
 extern void *_Nullable swift_task_enqueueGlobal_hook;
 
-SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+extern "C" SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_asyncMainDrainQueue [[noreturn]]();
 
 SWIFT_CC(swift)

--- a/Sources/XCTest/Private/ConcurrencySupport/ConcurrencySupport.cpp
+++ b/Sources/XCTest/Private/ConcurrencySupport/ConcurrencySupport.cpp
@@ -1,0 +1,25 @@
+#define SWIFT_CC_swift __attribute__((swiftcall))
+#define SWIFT_CC(CC) SWIFT_CC_##CC
+
+#define SWIFT_ATTRIBUTE_FOR_IMPORTS __attribute__((__visibility__("default")))
+#define SWIFT_EXPORT_FROM_ATTRIBUTE(LIBRARY) SWIFT_ATTRIBUTE_FOR_IMPORTS
+#define SWIFT_EXPORT_FROM(LIBRARY) SWIFT_EXPORT_FROM_ATTRIBUTE(LIBRARY)
+
+
+SWIFT_EXPORT_FROM(swift_Concurrency)
+extern void *_Nullable swift_task_enqueueGlobal_hook;
+
+extern "C" SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+void swift_task_donateThreadToGlobalExecutorUntil(bool (*condition)(void*),
+                                                  void *context);
+
+SWIFT_CC(swift)
+extern "C" void XCTMainRunLoopMain(void) {
+    // If the global executor is handled by outside environment (e.g. JavaScript),
+    // we can't donate thread because it will stop the outside event loop.
+    if (swift_task_enqueueGlobal_hook == nullptr) {
+        swift_task_donateThreadToGlobalExecutorUntil([](void *context) {
+            return false;
+        }, nullptr);
+    }
+}

--- a/Sources/XCTest/Private/ConcurrencySupport/ConcurrencySupport.cpp
+++ b/Sources/XCTest/Private/ConcurrencySupport/ConcurrencySupport.cpp
@@ -9,17 +9,14 @@
 SWIFT_EXPORT_FROM(swift_Concurrency)
 extern void *_Nullable swift_task_enqueueGlobal_hook;
 
-extern "C" SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
-void swift_task_donateThreadToGlobalExecutorUntil(bool (*condition)(void*),
-                                                  void *context);
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+void swift_task_asyncMainDrainQueue [[noreturn]]();
 
 SWIFT_CC(swift)
 extern "C" void XCTMainRunLoopMain(void) {
     // If the global executor is handled by outside environment (e.g. JavaScript),
     // we can't donate thread because it will stop the outside event loop.
     if (swift_task_enqueueGlobal_hook == nullptr) {
-        swift_task_donateThreadToGlobalExecutorUntil([](void *context) {
-            return false;
-        }, nullptr);
+        swift_task_asyncMainDrainQueue();
     }
 }

--- a/Sources/XCTest/Private/Shims.swift
+++ b/Sources/XCTest/Private/Shims.swift
@@ -1,0 +1,49 @@
+#if USE_SWIFT_CONCURRENCY_WAITER
+
+struct DispatchPredicate {
+    static func onQueue<X>(_: X) -> Self {
+        return DispatchPredicate()
+    }
+
+    static func notOnQueue<X>(_: X) -> Self {
+        return DispatchPredicate()
+    }
+}
+
+func dispatchPrecondition(condition: DispatchPredicate) {}
+
+extension XCTWaiter {
+    struct BlockingQueue {
+        init(label: String) {}
+
+        func sync<T>(_ body: () -> T) -> T {
+            body()
+        }
+        func async(_ body: @escaping () -> Void) {
+            body()
+        }
+    }
+
+    typealias DispatchQueue = BlockingQueue
+
+    struct RunLoop {
+        static let current = RunLoop()
+    }
+
+    class Thread: Equatable {
+        var threadDictionary: [String: Any] = [:]
+
+        static let current: Thread = Thread()
+
+        static func == (lhs: Thread, rhs: Thread) -> Bool {
+            return true
+        }
+    }
+}
+
+extension WaiterManager {
+    typealias DispatchQueue = XCTWaiter.DispatchQueue
+    typealias Thread = XCTWaiter.Thread
+}
+
+#endif

--- a/Sources/XCTest/Private/XCTestCase.TearDownBlocksState.swift
+++ b/Sources/XCTest/Private/XCTestCase.TearDownBlocksState.swift
@@ -22,13 +22,7 @@ extension XCTestCase {
         @available(macOS 12.0, *)
         func appendAsync(_ block: @Sendable @escaping () async throws -> Void) {
             self.append {
-                #if !os(WASI)
                 try awaitUsingExpectation { try await block() }
-                #else
-                Task {
-                    try await block()
-                }
-                #endif
             }
         }
 

--- a/Sources/XCTest/Private/XCTestCase.TearDownBlocksState.swift
+++ b/Sources/XCTest/Private/XCTestCase.TearDownBlocksState.swift
@@ -13,7 +13,7 @@ extension XCTestCase {
     final class TeardownBlocksState {
 
         private var wasFinalized = false
-        private var blocks: [() throws -> Void] = []
+        private var blocks: [() async throws -> Void] = []
 
         // We don't want to overload append(_:) below because of how Swift will implicitly promote sync closures to async closures,
         // which can unexpectedly change their semantics in difficult to track down ways.
@@ -21,8 +21,11 @@ extension XCTestCase {
         // Because of this, we chose the unusual decision to forgo overloading (which is a super sweet language feature <3) to prevent this issue from surprising any contributors to corelibs-xctest
         @available(macOS 12.0, *)
         func appendAsync(_ block: @Sendable @escaping () async throws -> Void) {
-            self.append {
-                try awaitUsingExpectation { try await block() }
+            XCTWaiter.subsystemQueue.sync {
+                precondition(wasFinalized == false, "API violation -- attempting to add a teardown block after teardown blocks have been dequeued")
+                blocks.append {
+                    try await awaitUsingExpectation { try await block() }
+                }
             }
         }
 
@@ -38,7 +41,7 @@ extension XCTestCase {
             #endif
         }
         
-        func finalize() -> [() throws -> Void] {
+        func finalize() -> [() async throws -> Void] {
             #if os(WASI)
             precondition(wasFinalized == false, "API violation -- attempting to run teardown blocks after they've already run")
             wasFinalized = true

--- a/Sources/XCTest/Public/XCAbstractTest.swift
+++ b/Sources/XCTest/Public/XCAbstractTest.swift
@@ -36,6 +36,8 @@ open class XCTest {
     /// testRunClass. If the test has not yet been run, this will be nil.
     open private(set) var testRun: XCTestRun? = nil
 
+    internal var performTask: Task<Void, Never>?
+
     /// The method through which tests are executed. Must be overridden by
     /// subclasses.
     open func perform(_ run: XCTestRun) {

--- a/Sources/XCTest/Public/XCTestCase.swift
+++ b/Sources/XCTest/Public/XCTestCase.swift
@@ -331,7 +331,6 @@ private func test<T: XCTestCase>(_ testFunc: @escaping (T) -> () throws -> Void)
     }
 }
 
-#if !os(WASI)
 @available(macOS 12.0, *)
 public func asyncTest<T: XCTestCase>(
     _ testClosureGenerator: @escaping (T) -> () async throws -> Void
@@ -381,7 +380,6 @@ private final class ThrownErrorWrapper: @unchecked Sendable {
         }
     }
 }
-#endif
 
 
 // This time interval is set to a very large value due to their being no real native timeout functionality within corelibs-xctest.

--- a/Sources/XCTest/Public/XCTestCase.swift
+++ b/Sources/XCTest/Public/XCTestCase.swift
@@ -233,13 +233,11 @@ open class XCTestCase: XCTest {
         }
 
         do {
-            #if !os(WASI)
             if #available(macOS 12.0, *) {
                 try awaitUsingExpectation {
                     try await self.setUp()
                 }
             }
-            #endif
         } catch {
             handleErrorDuringSetUp(error)
         }
@@ -281,13 +279,11 @@ open class XCTestCase: XCTest {
         }
 
         do {
-            #if !os(WASI)
             if #available(macOS 12.0, *) {
                 try awaitUsingExpectation {
                     try await self.tearDown()
                 }
             }
-            #endif
         } catch {
             handleErrorDuringTearDown(error)
         }

--- a/Sources/XCTest/Public/XCTestSuite.swift
+++ b/Sources/XCTest/Public/XCTestSuite.swift
@@ -45,12 +45,18 @@ open class XCTestSuite: XCTest {
 
         run.start()
         setUp()
+        self.performTask = Task {
         for test in tests {
             test.run()
+            if let childPerformTask = test.performTask {
+                _ = await childPerformTask.value
+            }
             testRun.addTestRun(test.testRun!)
         }
-        tearDown()
+        func doTearDown() { tearDown() }
+        doTearDown()
         run.stop()
+        }
     }
 
     public init(name: String) {


### PR DESCRIPTION
This patch unlocks expectation APIs (only for cooperative executor) and async test APIs (for both cooperative and JS event loop executor).

Expectation APIs around `XCTestExpectation` are designed to be blocking operations, and in single thread environment, it requires full control of event loop to process tasks while waiting.
Cooperative executor can process tasks until the expectations are fulfilled by donating the current thread (`swift_task_donateThreadToGlobalExecutorUntil`).

However, JS event loop executor can't control the event loop itself, so it cannot process tasks while waiting and it blocks JS event loop. Asyncify can pause the execution while waiting, and resume in next event loop. So we can provide expectation APIs with JS event loop executor in theory, but it brings a lot of complexity and requires AOT binary transformation by wasm-opt.
Also async style test can replace most use of expectation APIs, so this patch doesn't support them on JS event loop executor.

```swift

  func testQueueMicrotask() async {
    let _: () = await withUnsafeContinuation { continuation in
      _ = JSObject.global.queueMicrotask!(JSOneshotClosure { _ in
        continuation.resume(returning: ())
        return .undefined
      })
    }
  }
```
